### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.0.0
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: nbr41/gosudoku
           username: ${{secrets.DOCKER_USERNAME}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore